### PR TITLE
modify libc function vprintfmt & fputch

### DIFF
--- a/ucore/src/lib/printfmt.c
+++ b/ucore/src/lib/printfmt.c
@@ -120,6 +120,52 @@ printfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, 
     va_end(ap);
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* *
  * vprintfmt - format a string and print it by using putch, it's called with a va_list
  * instead of a variable number of arguments
@@ -132,6 +178,290 @@ printfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, 
  * Call this function if you are already dealing with a va_list.
  * Or you probably want printfmt() instead.
  * */
+
+
+
+static inline int isdigit(int c)
+{
+	return '0' <= c && c <= '9';
+}
+
+static int skip_atoi(const char **s)
+{
+	int i = 0;
+
+	while (isdigit(**s))
+		i = i * 10 + *((*s)++) - '0';
+	return i;
+}
+
+#define ZEROPAD	1		/* pad with zero */
+#define SIGN	2		/* unsigned/signed long */
+#define PLUS	4		/* show plus */
+#define SPACE	8		/* space if plus */
+#define LEFT	16		/* left justified */
+#define SMALL	32		/* Must be 32 == 0x20 */
+#define SPECIAL	64		/* 0x */
+
+#define __do_div(n, base) ({ \
+int __res; \
+__res = ((unsigned long) n) % (unsigned) base; \
+n = ((unsigned long) n) / (unsigned) base; \
+__res; })
+
+static char *number(char *str, long num, int base, int size, int precision,
+		    int type)
+{
+	/* we are called with base 8, 10 or 16, only, thus don't need "G..."  */
+	static const char digits[16] = "0123456789ABCDEF"; /* "GHIJKLMNOPQRSTUVWXYZ"; */
+
+	char tmp[66];
+	char c, sign, locase;
+	int i;
+
+	/* locase = 0 or 0x20. ORing digits or letters with 'locase'
+	 * produces same digits or (maybe lowercased) letters */
+	locase = (type & SMALL);
+	if (type & LEFT)
+		type &= ~ZEROPAD;
+	if (base < 2 || base > 16)
+		return NULL;
+	c = (type & ZEROPAD) ? '0' : ' ';
+	sign = 0;
+	if (type & SIGN) {
+		if (num < 0) {
+			sign = '-';
+			num = -num;
+			size--;
+		} else if (type & PLUS) {
+			sign = '+';
+			size--;
+		} else if (type & SPACE) {
+			sign = ' ';
+			size--;
+		}
+	}
+	if (type & SPECIAL) {
+		if (base == 16)
+			size -= 2;
+		else if (base == 8)
+			size--;
+	}
+	i = 0;
+	if (num == 0)
+		tmp[i++] = '0';
+	else
+		while (num != 0)
+			tmp[i++] = (digits[__do_div(num, base)] | locase);
+	if (i > precision)
+		precision = i;
+	size -= precision;
+	if (!(type & (ZEROPAD + LEFT)))
+		while (size-- > 0)
+			*str++ = ' ';
+	if (sign)
+		*str++ = sign;
+	if (type & SPECIAL) {
+		if (base == 8)
+			*str++ = '0';
+		else if (base == 16) {
+			*str++ = '0';
+			*str++ = ('X' | locase);
+		}
+	}
+	if (!(type & LEFT))
+		while (size-- > 0)
+			*str++ = c;
+	while (i < precision--)
+		*str++ = '0';
+	while (i-- > 0)
+		*str++ = tmp[i];
+	while (size-- > 0)
+		*str++ = ' ';
+	return str;
+}
+
+void 
+vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, va_list ap)
+{
+	int len;
+	unsigned long num;
+	int i, base;
+	char buf[1024];
+	char *str;
+	const char *s;
+
+	int flags;		/* flags to number() */
+
+	int field_width;	/* width of output field */
+	int precision;		/* min. # of digits for integers; max
+				   number of chars for from string */
+	int qualifier;		/* 'h', 'l', or 'L' for integer fields */
+
+	for (str = buf; *fmt; ++fmt) {
+		if (*fmt != '%') {
+			*str++ = *fmt;
+			continue;
+		}
+
+		/* process flags */
+		flags = 0;
+	      repeat:
+		++fmt;		/* this also skips first '%' */
+		switch (*fmt) {
+		case '-':
+			flags |= LEFT;
+			goto repeat;
+		case '+':
+			flags |= PLUS;
+			goto repeat;
+		case ' ':
+			flags |= SPACE;
+			goto repeat;
+		case '#':
+			flags |= SPECIAL;
+			goto repeat;
+		case '0':
+			flags |= ZEROPAD;
+			goto repeat;
+		}
+
+		/* get field width */
+		field_width = -1;
+		if (isdigit(*fmt))
+			field_width = skip_atoi(&fmt);
+		else if (*fmt == '*') {
+			++fmt;
+			/* it's the next argument */
+			field_width = va_arg(ap, int);
+			if (field_width < 0) {
+				field_width = -field_width;
+				flags |= LEFT;
+			}
+		}
+
+		/* get the precision */
+		precision = -1;
+		if (*fmt == '.') {
+			++fmt;
+			if (isdigit(*fmt))
+				precision = skip_atoi(&fmt);
+			else if (*fmt == '*') {
+				++fmt;
+				/* it's the next argument */
+				precision = va_arg(ap, int);
+			}
+			if (precision < 0)
+				precision = 0;
+		}
+
+		/* get the conversion qualifier */
+		qualifier = -1;
+		if (*fmt == 'h' || *fmt == 'l' || *fmt == 'L') {
+			qualifier = *fmt;
+			++fmt;
+		}
+
+		/* default base */
+		base = 10;
+
+		switch (*fmt) {
+		case 'c':
+			if (!(flags & LEFT))
+				while (--field_width > 0)
+					*str++ = ' ';
+			*str++ = (unsigned char)va_arg(ap, int);
+			while (--field_width > 0)
+				*str++ = ' ';
+			continue;
+
+		case 's':
+			s = va_arg(ap, char *);
+			len = strnlen(s, precision);
+
+			if (!(flags & LEFT))
+				while (len < field_width--)
+					*str++ = ' ';
+			for (i = 0; i < len; ++i)
+				*str++ = *s++;
+			while (len < field_width--)
+				*str++ = ' ';
+			continue;
+
+		case 'p':
+			if (field_width == -1) {
+				field_width = 2 * sizeof(void *);
+				flags |= ZEROPAD;
+			}
+			str = number(str,
+				     (unsigned long)va_arg(ap, void *), 16,
+				     field_width, precision, flags);
+			continue;
+
+		case 'n':
+			if (qualifier == 'l') {
+				long *ip = va_arg(ap, long *);
+				*ip = (str - buf);
+			} else {
+				int *ip = va_arg(ap, int *);
+				*ip = (str - buf);
+			}
+			continue;
+
+		case '%':
+			*str++ = '%';
+			continue;
+
+			/* integer number formats - set up the flags and "break" */
+		case 'o':
+			base = 8;
+			break;
+
+		case 'x':
+			flags |= SMALL;
+		case 'X':
+			base = 16;
+			break;
+
+		case 'd':
+		case 'i':
+			flags |= SIGN;
+		case 'u':
+			break;
+
+		default:
+			*str++ = '%';
+			if (*fmt)
+				*str++ = *fmt;
+			else
+				--fmt;
+			continue;
+		}
+		if (qualifier == 'l')
+			num = va_arg(ap, unsigned long);
+		else if (qualifier == 'h') {
+			num = (unsigned short)va_arg(ap, int);
+			if (flags & SIGN)
+				num = (short)num;
+		} else if (flags & SIGN)
+			num = va_arg(ap, int);
+		else
+			num = va_arg(ap, unsigned int);
+		str = number(str, num, base, field_width, precision, flags);
+	}
+	*str = '\0';
+	for (str = buf; *str; ++str) {
+		putch(*str, putdat, fd);
+	}
+	putch('\0', putdat, fd);
+}
+
+
+
+
+
+
+/*
 void
 vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, va_list ap) {
     register const char *p;
@@ -142,6 +472,7 @@ vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt,
     while (1) {
         while ((ch = *(unsigned char *)fmt ++) != '%') {
             if (ch == '\0') {
+		putch('\0', putdat, fd);
                 return;
             }
             putch(ch, putdat, fd);
@@ -288,11 +619,45 @@ vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt,
         default:
             putch('%', putdat, fd);
             for (fmt --; fmt[-1] != '%'; fmt --)
-                /* do nothing */;
+                ;//do nothing
             break;
         }
     }
 }
+*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 /* sprintbuf is used to save enough information of a buffer */
 struct sprintbuf {

--- a/ucore/src/lib/printfmt.c
+++ b/ucore/src/lib/printfmt.c
@@ -40,147 +40,6 @@ static const char * const error_string[MAXERROR + 1] = {
     [E_NOTEMPTY]            "directory is not empty",
 };
 
-/* *
- * printnum - print a number (base <= 16) in reverse order
- * @putch:      specified putch function, print a single character
- * @fd:         file descriptor
- * @putdat:     used by @putch function
- * @num:        the number will be printed
- * @base:       base for print, must be in [1, 16]
- * @width:      maximum number of digits, if the actual width is less than @width, use @padc instead
- * @padc:       character that padded on the left if the actual width is less than @width
- * */
-static void
-printnum(void (*putch)(int, void*, int), int fd, void *putdat,
-        unsigned long long num, unsigned base, int width, int padc) {
-    unsigned long long result = num;
-    unsigned mod = do_div(result, base);
-
-    // first recursively print all preceding (more significant) digits
-    if (num >= base) {
-        printnum(putch, fd, putdat, result, base, width - 1, padc);
-    } else {
-        // print any needed pad characters before first digit
-        while (-- width > 0)
-            putch(padc, putdat, fd);
-    }
-    // then print this (the least significant) digit
-    putch("0123456789abcdef"[mod], putdat, fd);
-}
-
-/* *
- * getuint - get an unsigned int of various possible sizes from a varargs list
- * @ap:         a varargs list pointer
- * @lflag:      determines the size of the vararg that @ap points to
- * */
-static unsigned long long
-getuint(va_list *ap, int lflag) {
-    if (lflag >= 2) {
-        return va_arg(*ap, unsigned long long);
-    }
-    else if (lflag) {
-        return va_arg(*ap, unsigned long);
-    }
-    else {
-        return va_arg(*ap, unsigned int);
-    }
-}
-
-/* *
- * getint - same as getuint but signed, we can't use getuint because of sign extension
- * @ap:         a varargs list pointer
- * @lflag:      determines the size of the vararg that @ap points to
- * */
-static long long
-getint(va_list *ap, int lflag) {
-    if (lflag >= 2) {
-        return va_arg(*ap, long long);
-    }
-    else if (lflag) {
-        return va_arg(*ap, long);
-    }
-    else {
-        return va_arg(*ap, int);
-    }
-}
-
-/* *
- * printfmt - format a string and print it by using putch
- * @putch:      specified putch function, print a single character
- * @fd:         file descriptor
- * @putdat:     used by @putch function
- * @fmt:        the format string to use
- * */
-void
-printfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, ...) {
-    va_list ap;
-
-    va_start(ap, fmt);
-    vprintfmt(putch, fd, putdat, fmt, ap);
-    va_end(ap);
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/* *
- * vprintfmt - format a string and print it by using putch, it's called with a va_list
- * instead of a variable number of arguments
- * @fd:         file descriptor
- * @putch:      specified putch function, print a single character
- * @putdat:     used by @putch function
- * @fmt:        the format string to use
- * @ap:         arguments for the format string
- *
- * Call this function if you are already dealing with a va_list.
- * Or you probably want printfmt() instead.
- * */
-
-
-
 static inline int isdigit(int c)
 {
 	return '0' <= c && c <= '9';
@@ -280,6 +139,99 @@ static char *number(char *str, long num, int base, int size, int precision,
 		*str++ = ' ';
 	return str;
 }
+
+/* *
+ * printnum - print a number (base <= 16) in reverse order
+ * @putch:      specified putch function, print a single character
+ * @fd:         file descriptor
+ * @putdat:     used by @putch function
+ * @num:        the number will be printed
+ * @base:       base for print, must be in [1, 16]
+ * @width:      maximum number of digits, if the actual width is less than @width, use @padc instead
+ * @padc:       character that padded on the left if the actual width is less than @width
+ * */
+static void
+printnum(void (*putch)(int, void*, int), int fd, void *putdat,
+        unsigned long long num, unsigned base, int width, int padc) {
+    unsigned long long result = num;
+    unsigned mod = do_div(result, base);
+
+    // first recursively print all preceding (more significant) digits
+    if (num >= base) {
+        printnum(putch, fd, putdat, result, base, width - 1, padc);
+    } else {
+        // print any needed pad characters before first digit
+        while (-- width > 0)
+            putch(padc, putdat, fd);
+    }
+    // then print this (the least significant) digit
+    putch("0123456789abcdef"[mod], putdat, fd);
+}
+
+/* *
+ * getuint - get an unsigned int of various possible sizes from a varargs list
+ * @ap:         a varargs list pointer
+ * @lflag:      determines the size of the vararg that @ap points to
+ * */
+static unsigned long long
+getuint(va_list *ap, int lflag) {
+    if (lflag >= 2) {
+        return va_arg(*ap, unsigned long long);
+    }
+    else if (lflag) {
+        return va_arg(*ap, unsigned long);
+    }
+    else {
+        return va_arg(*ap, unsigned int);
+    }
+}
+
+/* *
+ * getint - same as getuint but signed, we can't use getuint because of sign extension
+ * @ap:         a varargs list pointer
+ * @lflag:      determines the size of the vararg that @ap points to
+ * */
+static long long
+getint(va_list *ap, int lflag) {
+    if (lflag >= 2) {
+        return va_arg(*ap, long long);
+    }
+    else if (lflag) {
+        return va_arg(*ap, long);
+    }
+    else {
+        return va_arg(*ap, int);
+    }
+}
+
+/* *
+ * printfmt - format a string and print it by using putch
+ * @putch:      specified putch function, print a single character
+ * @fd:         file descriptor
+ * @putdat:     used by @putch function
+ * @fmt:        the format string to use
+ * */
+void
+printfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, ...) {
+    va_list ap;
+
+    va_start(ap, fmt);
+    vprintfmt(putch, fd, putdat, fmt, ap);
+    va_end(ap);
+}
+
+/* *
+ * vprintfmt - format a string and print it by using putch, it's called with a va_list
+ * instead of a variable number of arguments
+ * @fd:         file descriptor
+ * @putch:      specified putch function, print a single character
+ * @putdat:     used by @putch function
+ * @fmt:        the format string to use
+ * @ap:         arguments for the format string
+ *
+ * Call this function if you are already dealing with a va_list.
+ * Or you probably want printfmt() instead.
+ * */
 
 void 
 vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, va_list ap)
@@ -455,209 +407,6 @@ vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt,
 	}
 	putch('\0', putdat, fd);
 }
-
-
-
-
-
-
-/*
-void
-vprintfmt(void (*putch)(int, void*, int), int fd, void *putdat, const char *fmt, va_list ap) {
-    register const char *p;
-    register int ch, err;
-    unsigned long long num;
-    int base, width, precision, lflag, altflag;
-
-    while (1) {
-        while ((ch = *(unsigned char *)fmt ++) != '%') {
-            if (ch == '\0') {
-		putch('\0', putdat, fd);
-                return;
-            }
-            putch(ch, putdat, fd);
-        }
-
-        // Process a %-escape sequence
-        char padc = ' ';
-        width = precision = -1;
-        lflag = altflag = 0;
-
-    reswitch:
-        switch (ch = *(unsigned char *)fmt ++) {
-
-        // flag to pad on the right
-        case '-':
-            padc = '-';
-            goto reswitch;
-
-        // flag to pad with 0's instead of spaces
-        case '0':
-            padc = '0';
-            goto reswitch;
-
-        // width field
-        case '1' ... '9':
-            for (precision = 0; ; ++ fmt) {
-                precision = precision * 10 + ch - '0';
-                ch = *fmt;
-                if (ch < '0' || ch > '9') {
-                    break;
-                }
-            }
-            goto process_precision;
-
-        case '*':
-            precision = va_arg(ap, int);
-            goto process_precision;
-
-        case '.':
-            if (width < 0)
-                width = 0;
-            goto reswitch;
-
-        case '#':
-            altflag = 1;
-            goto reswitch;
-
-        process_precision:
-            if (width < 0)
-                width = precision, precision = -1;
-            goto reswitch;
-
-        // long flag (doubled for long long)
-        case 'l':
-            lflag ++;
-            goto reswitch;
-
-        // character
-        case 'c':
-            putch(va_arg(ap, int), putdat, fd);
-            break;
-
-        // error message
-        case 'e':
-            err = va_arg(ap, int);
-            if (err < 0) {
-                err = -err;
-            }
-            if (err > MAXERROR || (p = error_string[err]) == NULL) {
-                printfmt(putch, fd, putdat, "error %d", err);
-            }
-            else {
-                printfmt(putch, fd, putdat, "%s", p);
-            }
-            break;
-
-        // string
-        case 's':
-            if ((p = va_arg(ap, char *)) == NULL) {
-                p = "(null)";
-            }
-            if (width > 0 && padc != '-') {
-                for (width -= strnlen(p, precision); width > 0; width --) {
-                    putch(padc, putdat, fd);
-                }
-            }
-            for (; (ch = *p ++) != '\0' && (precision < 0 || -- precision >= 0); width --) {
-                if (altflag && (ch < ' ' || ch > '~')) {
-                    putch('?', putdat, fd);
-                }
-                else {
-                    putch(ch, putdat, fd);
-                }
-            }
-            for (; width > 0; width --) {
-                putch(' ', putdat, fd);
-            }
-            break;
-
-        // (signed) decimal
-        case 'd':
-            num = getint(&ap, lflag);
-            if ((long long)num < 0) {
-                putch('-', putdat, fd);
-                num = -(long long)num;
-            }
-            base = 10;
-            goto number;
-
-        // unsigned decimal
-        case 'u':
-            num = getuint(&ap, lflag);
-            base = 10;
-            goto number;
-
-        // (unsigned) octal
-        case 'o':
-            num = getuint(&ap, lflag);
-            base = 8;
-            goto number;
-
-        // pointer
-        case 'p':
-            putch('0', putdat, fd);
-            putch('x', putdat, fd);
-            num = (unsigned long long)(uintptr_t)va_arg(ap, void *);
-            base = 16;
-            goto number;
-
-        // (unsigned) hexadecimal
-        case 'x':
-            num = getuint(&ap, lflag);
-            base = 16;
-        number:
-            printnum(putch, fd, putdat, num, base, width, padc);
-            break;
-
-        // escaped '%' character
-        case '%':
-            putch(ch, putdat, fd);
-            break;
-
-        // unrecognized escape sequence - just print it literally
-        default:
-            putch('%', putdat, fd);
-            for (fmt --; fmt[-1] != '%'; fmt --)
-                ;//do nothing
-            break;
-        }
-    }
-}
-*/
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 /* sprintbuf is used to save enough information of a buffer */
 struct sprintbuf {

--- a/ucore/src/lib/stdio.c
+++ b/ucore/src/lib/stdio.c
@@ -5,10 +5,19 @@
 #include <ulib.h>
 #include <unistd.h>
 
+char buf[1024];
+int buf_pos = 0;
+
 static void
 fputch(char c, int *cnt, int fd) {
-    write(fd, &c, sizeof(char));
-    (*cnt) ++;
+    if(c != '\0'){
+        buf[buf_pos++] = c;
+    }
+    else{
+        (*cnt) = buf_pos;
+        write(fd, buf, buf_pos);
+        buf_pos = 0;
+    }
 }
 
 /* *


### PR DESCRIPTION
fix the bug of function cprintf in libc.

Previous: 
cprintf is done by calling syscall for every single character that need to write.
format bug exists, can be found in test badarg.

Now:
Every syscall is handled by single sys_write syscall.
format bug fixed by following the codes from Linux repo.