### PR TITLE
Bugfixes and new features for Rust userland.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ else ifeq ($(MODE), debug)
 cmake_build_args += -DCMAKE_BUILD_TYPE=Debug
 endif
 
-.PHONY: all clean build rust ucore biscuit app bin busybox nginx redis alpine iperf3 musl-gcc pre make libc-test vmm
+.PHONY: all clean build rust ucore biscuit app bin busybox nginx redis alpine iperf3 musl-gcc pre make libc-test vmm rust-rvm-vmm
 
 all: build
 
@@ -66,8 +66,9 @@ rust:
 ifeq ($(EN_RUST), y)
 	@echo Building rust programs
 	@cd rust && cargo build $(rust_build_args)
+	@for i in $(rust_bins); do make -f rust/Makefile strip STRIP_FILE=$$i; done
 	@rm -rf $(out_dir)/rust && mkdir -p $(out_dir)/rust
-	@cp $(rust_bins) $(out_dir)/rust
+	@for i in $(rust_bins); do cp $$i-strip $(out_dir)/rust/$$(basename $$i); done
 else
 	@echo Building rust disabled
 endif

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,0 +1,4 @@
+STRIP=$(ARCH)-linux-musl-strip
+.PHONY: strip
+strip:
+	$(STRIP) $(STRIP_FILE) -o $(STRIP_FILE)-strip

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -187,6 +187,8 @@ impl fmt::Write for StdOut {
         }
     }
 }
+pub const F_GETFL: usize = 3; /* get file->f_flags */
+pub const F_SETFL: usize = 4; /* set file->f_flags */
 
 /* VFS flags */
 // TODO: use bitflags
@@ -199,3 +201,4 @@ pub const O_CREAT: usize = 0x00000004; // create file if it does not exist
 pub const O_EXCL: usize = 0x00000008; // error if O_CREAT and the file exists
 pub const O_TRUNC: usize = 0x00000010; // truncate file upon open
 pub const O_APPEND: usize = 0x00000020; // append on each write
+pub const O_NONBLOCK: usize = 0o4000;

--- a/rust/src/syscall.rs
+++ b/rust/src/syscall.rs
@@ -91,21 +91,28 @@ pub fn sys_read(fd: usize, base: *mut u8, len: usize) -> i32 {
 }
 
 pub fn sys_open(path: &str, flags: usize) -> i32 {
-    // UNSAFE: append '\0' to the string
-    use core::mem::replace;
-    let end = unsafe { &mut *(path.as_ptr().offset(path.len() as isize) as *mut u8) };
-    let backup = replace(end, 0);
+    // Converting &str to &CStr is impossible without memcpy, according to https://cheats.rs/ .
+    use alloc::vec::Vec;
+    fn str_to_cstr(s: &str)->Vec<u8>{
+        let str_len = s.len();
+        let mut buf = Vec::with_capacity(str_len+1);
+        for i in s.as_bytes(){
+            buf.push(*i);
+        }
+        buf.push(0);
+        buf
+    }
+    let path_cstr = str_to_cstr(path);
     const AT_FDCWD: isize = -100;
     let ret = sys_call(
         SyscallId::Openat,
         AT_FDCWD as usize,
-        path.as_ptr() as usize,
+        path_cstr.as_ptr() as usize,
         flags,
         0,
         0,
         0,
     );
-    *end = backup;
     ret
 }
 

--- a/rust/src/syscall.rs
+++ b/rust/src/syscall.rs
@@ -316,6 +316,14 @@ pub fn sys_sendto(
     )
 }
 
+pub fn sys_fcntl_0(fd: usize, cmd: usize)->i32{
+    sys_call(SyscallId::Fcntl, fd, cmd, 0, 0, 0, 0)
+}
+
+pub fn sys_fcntl_1(fd: usize, cmd: usize, arg1: usize) -> i32{
+    sys_call(SyscallId::Fcntl, fd, cmd, arg1, 0, 0, 0)
+}
+
 pub fn sys_ioctl(fd: usize, request: usize, arg1: usize) -> i32 {
     sys_call(SyscallId::Ioctl, fd, request, arg1, 0, 0, 0)
 }
@@ -506,6 +514,7 @@ enum SyscallId {
     Mmap = 222,
     Munmap = 215,
     Ioctl = 29,
+    Fcntl = 25,
     Yield = 124,
     Socket = 198,
     SendTo = 206,


### PR DESCRIPTION
1. 加入fcntl的支持（rvm要用）
2. rust编译产物太大，直接导致sfsimg过大，间接导致link_user用不了（kernel.img把device tree覆盖了）；在Makefile里加了一步strip，减小rust编译产物体积（经测试riscv64下link_user可以用）
3. sys_open的魔法不能作用在常量区，修改成正常版本（复制一份path）

Known issues：还需要把sfsimg略微扩大，否则会报越界