### PR TITLE
Make global variables in userlib `static` 

### DIFF
--- a/ucore/src/lib/dir.c
+++ b/ucore/src/lib/dir.c
@@ -8,7 +8,8 @@
 #include <error.h>
 #include <unistd.h>
 
-DIR dir, *dirp=&dir;
+static DIR dir, *dirp=&dir;
+
 DIR *
 opendir(const char *path) {
 

--- a/ucore/src/lib/stdio.c
+++ b/ucore/src/lib/stdio.c
@@ -5,8 +5,8 @@
 #include <ulib.h>
 #include <unistd.h>
 
-char buf[1024];
-int buf_pos = 0;
+static char buf[1024];
+static int buf_pos = 0;
 
 static void
 fputch(char c, int *cnt, int fd) {


### PR DESCRIPTION
Add `static` for global vars in user-lib to avoid naming conflicts with user programs.